### PR TITLE
Implement more tagtypes commands

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -639,6 +639,26 @@ impl<S: Read + Write> Client<S> {
         self.run_command("tagtypes", ()).and_then(|_| self.read_list("tagtype"))
     }
 
+    /// Enable these tag types in future responses
+    pub fn tagtypes_enable(&mut self) -> Result<()> {
+        self.run_command("tagtypes enable", ()).and_then(|_| self.expect_ok())
+    }
+
+    /// Enable all tag types in future responses
+    pub fn tagtypes_all(&mut self) -> Result<()> {
+        self.run_command("tagtypes all", ()).and_then(|_| self.expect_ok())
+    }
+
+    /// Disable these tag types in future responses
+    pub fn tagtypes_disable(&mut self, tagtypes: Vec<&str>) -> Result<()> {
+        self.run_command("tagtypes disable", tagtypes).and_then(|_| self.expect_ok())
+    }
+
+    /// Disable all tag types in future responses
+    pub fn tagtypes_clear(&mut self) -> Result<()> {
+        self.run_command("tagtypes clear", ()).and_then(|_| self.expect_ok())
+    }
+
     /// List all available decoder plugins
     pub fn decoders(&mut self) -> Result<Vec<Plugin>> {
         self.run_command("decoders", ()).and_then(|_| self.read_struct())

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -287,6 +287,16 @@ impl <'a> ToArguments for &Cow<'a, str> {
     }
 }
 
+impl <'a, T: ToArguments> ToArguments for Vec<T> {
+    fn to_arguments<F, E>(&self, f: &mut F) -> StdResult<(), E>
+    where F: FnMut(&str) -> StdResult<(), E> {
+        for arg in self.iter() {
+            arg.to_arguments(f)?
+        }
+        Ok(())
+    }
+}
+
 macro_rules! argument_for_display {
     ( $x:path ) => {
         impl ToArguments for $x {


### PR DESCRIPTION
Add `tagtypes clear`, `tagtypes all`, `tagtypes enable` and `tagtypes disable`. These will come in handy for local dynamic playlists in Euphonica as well as for future performance optimisations.